### PR TITLE
fix: ensure 1-minute quiz option always available

### DIFF
--- a/scope/src/components/ChooseScope.tsx
+++ b/scope/src/components/ChooseScope.tsx
@@ -34,6 +34,9 @@ export const ChooseScope: React.FC = () => {
     }, [loadQuestions])
 
     function canSupportTime(minutes: number, questions: QuestionConfig[]) {
+        // Always allow 1-minute option regardless of available questions
+        if (minutes === 1) return true
+        
         const totalAvailableSec = questions.reduce((sum, q) => {
             const maxSec = q.level === 1 ? 10 : q.level === 2 ? 20 : 30
             return sum + maxSec


### PR DESCRIPTION
Always allow 1-minute quiz duration regardless of question pool size.

Previously, the 1-minute option would be disabled when there weren't enough questions to fill the time period. This change bypasses the validation for the 1-minute option while preserving checks for 2 and 3 minute durations.